### PR TITLE
Timers & Basic Events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ conan_basic_setup()
 ## Pembroke Library Definition
 ## ---
 add_library(pembroke
+    src/event.cpp
     src/http/request.cpp
     src/internal/logging.cpp
     src/reactor.cpp

--- a/include/event.hpp
+++ b/include/event.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include "internal/forward_decls.hpp"
+#include "util/func.hpp"
+
+namespace pembroke {
+
+    /**
+     * @breif Represents any event that has been scheduled on the Reactor
+     *
+     * The sole purpose of the `Event` class is to handle cancellation. The class
+     * generically handles different types of events (I/O, timers, etc).
+     */
+    class Event {
+    private:
+        std::function<bool()> m_cancel_func;
+
+    public:
+        Event(std::function<bool()> m_cancel_func) noexcept;
+
+        /**
+         * @brief Cancels the event if it has not already completed and had it's
+         *        callback run. If the event has completed, calling `cancel()` will
+         *        return True and have not effect.
+         * @returns True if successfully canceled, False otherwise
+         */
+        bool cancel() noexcept;
+    };
+
+    /**
+     * @brief A companion class to Event that helps with internal bookeeping to any class
+     *        that is managing and executing events.
+     * @see pembroke::Reactor
+     */
+    struct EventContext {
+        const uint64_t key;                    /**< Unique Identifier for ctx */
+        const std::function<void()> callback;  /**< Callback called on `cancel()` */
+        const struct event *event = nullptr;   /**< Event object that class represents */
+
+        std::function<void()> post_event_cleanup = util::nop_f;
+
+        EventContext(uint64_t key, std::function<void()> cb) noexcept;
+    };
+
+    /** @brief Required operator for using EventContext within a set/map */
+    inline bool operator==(const EventContext &lhs, const EventContext &rhs) {
+        return lhs.key == rhs.key;
+    }
+
+    /** @brief Simple hash function to support using EventContext within a set/map */
+    struct EventContextHash {
+        size_t operator() (const std::shared_ptr<EventContext> &ctx) const;
+    };
+
+} // namespace pembroke

--- a/include/internal/forward_decls.hpp
+++ b/include/internal/forward_decls.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+/* 
+ * A single header to import if an event2 C-struct or function is needed in a publicly
+ * visible header. This forward declares whatever is needed.
+ */
+
+extern "C" {
+
+    // ---
+    // Structs
+    // ---
+    struct event_base;
+    struct event;
+
+    // ---
+    // Functions
+    // ---
+    void event_base_free(event_base *);
+    void event_free(event *);
+
+}

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -1,20 +1,29 @@
 #pragma once
 
 #include <chrono>
+#include <functional>
 #include <memory>
+#include <unordered_map>
+#include <variant>
 
 #include "reactor.hpp"
 #include "task.hpp"
 
 namespace pembroke {
+    using namespace std::chrono_literals;
+
+    const auto no_delay = 0s;
 
     /**
      * @brief A handle to cancel tasks that have been scheduled on a reactor
      */
     class Cancelable {
     private:
-        // TODO: Define some kind of handle that can be used
+        /** @brief Callback provided at construction, to be invoked by `cancel()` */
+        std::function<bool()> m_cancel_cb;
     public:
+
+        Cancelable(std::function<bool()>) noexcept;
         /**
          * @brief Attempts to cancel an event on the reactor
          * 
@@ -39,15 +48,35 @@ namespace pembroke {
      */
     class Scheduler {
         friend class Reactor;
-
     private:
         const Reactor *m_reactor;
+        uint32_t m_task_index{0};
+        std::unordered_map<int, int> m_timers{};
 
         Scheduler(const Reactor *r);
     
     public:
         [[nodiscard]]
         std::shared_ptr<Cancelable> schedule_once(const Task &t, const std::chrono::duration<long, std::micro> &delay) noexcept;
+
+    private:
+        /**
+         * @brief Submit a task to run on a specific schedule configuration.
+         * 
+         * All scheduling functions funnel into here and the public interface exposes a much
+         * more user-friendly interface to interact with.
+         */
+        [[nodiscard]]
+        std::shared_ptr<Cancelable> schedule(const Task &t,
+            const std::chrono::duration<long, std::micro> &delay,
+            std::variant<bool, uint32_t> repeat,
+            const std::chrono::duration<long, std::micro> &interval) noexcept;
+
+        static void handle_timer(int, short, void *arg) noexcept;
     };
+
+    void Scheduler::handle_timer(int, short, void *arg) noexcept {
+
+    }
 
 } // namespace pembroke

--- a/include/task.hpp
+++ b/include/task.hpp
@@ -2,16 +2,16 @@
 
 #include <functional>
 
-namespace pembroke {
+#include "util/func.hpp"
 
-    constexpr auto nop_f = []() -> void {};
+namespace pembroke {
 
     /**
      * @brief A simple task to run in the context of a Reactor
      */
     class Task {
     private:
-        std::function<void()> m_f = nop_f;
+        std::function<void()> m_f = util::nop_f;
         
     public:
         Task(std::function<void()> f);

--- a/include/util/func.hpp
+++ b/include/util/func.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace pembroke::util {
+    constexpr auto nop_f = []() -> void {};
+}

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -1,0 +1,38 @@
+#include "event.hpp"
+
+#include <exception>
+#include <sstream>
+
+#include "internal/logging.hpp"
+
+namespace pembroke {
+
+    Event::Event(std::function<bool()> cf) noexcept:
+        m_cancel_func(cf) {}
+
+    bool Event::cancel() noexcept {
+        try {
+            return m_cancel_func();
+        } catch (const std::exception &ex) {
+            std::stringstream ss;
+            ss << "Uncaught exception encountered while cancelling event: "
+               << ex.what();
+            logger::error(ss.str());
+        } catch (...) {
+            logger::error(
+                "Uncaught exceptionof an unknown type encountered "
+                "(not defined within class heirarchy of std::exception) "
+                "while cancelling event");
+        }
+
+        return false;
+    }
+
+    EventContext::EventContext(uint64_t key, std::function<void()> cb) noexcept:
+        key(key), callback(cb) {}
+
+    size_t EventContextHash::operator() (const std::shared_ptr<EventContext> &ctx) const {
+        return static_cast<size_t>(ctx->key);
+    }
+
+} // namespace pembroke

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -1,1 +1,35 @@
 #include "scheduler.hpp"
+
+extern "C" {
+#include <event2/event.h>
+}
+
+namespace pembroke {
+    // ---
+    // Cancelable Code
+    // ---
+    Cancelable::Cancelable(std::function<bool()> f) noexcept: m_cancel_cb(f) {}
+
+    bool Cancelable::cancel() const noexcept {
+        return m_cancel_cb();
+    }
+
+    // ---
+    // Scheduler Code
+    // ---
+    Scheduler::Scheduler(const Reactor *r): m_reactor(r) {}
+
+    std::shared_ptr<Cancelable> Scheduler::schedule(const Task &t,
+        const std::chrono::duration<long, std::micro> &delay,
+        std::variant<bool, uint32_t> repeat,
+        const std::chrono::duration<long, std::micro> &interval) noexcept
+    {
+        // TODO: register task and index within the class somewhere as a context
+        // TODO: provide a reference to this context as the cb arg
+        auto task_index = ++m_task_index;
+        evtimer_new(nullptr, Scheduler::handle_timer, &task_index);
+
+        // TODO: wrap this all up in a call to the reactor since the `base` is needed
+        return nullptr;
+    }
+}

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -13,13 +13,13 @@ namespace pembroke {
             m_f();
         } catch (const std::exception &ex) {
             std::stringstream ss;
-            ss << "Uncaught exception encountered while running task"
+            ss << "Uncaught exception encountered while running task: "
                << ex.what();
             logger::error(ss.str());
         } catch (...) {
             logger::error(
                 "Uncaught exception of an uknown type encountered "
-                "(not defined within class heirarcy of std::exception) "
+                "(not defined within class heirarchy of std::exception) "
                 "while running task");
         }
     }


### PR DESCRIPTION
Added support to schedule a callback after a specified time-duration
(timer). This introduces the generic `Event` class which acts as a
handle to any event produced by the underlying libevent. Right now the
only supported action on the event is cancellation, but the event is
intended to be generic across all events produced by libevent.

This lays the foundation for a scheduler and higher level concepts such
as Tasks or Futures.