### PR TITLE
Sanitizer support - Resolves #5

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,14 @@
+# CircleCI
+
+This folder contains all the configuration files and scripts necessary to run tests on
+CircleCI.
+
+| __File__              | __Function__                                                     |
+|-----------------------|------------------------------------------------------------------|
+| `conan_setup.sh`      | Installs [conan][conan] along with a configuration to use Clang, and downloads and compiles 3rd party dependencies |
+| `clang.conan_profile` | Clang configuration file installed by `conan_setup.sh`           |
+| `cmake_setup.sh`      | Configure cmake with sanitizer and optimization options          |
+| `config.yml`          | CircleCI configuration with all job definitions                  |
+
+
+  [conan]: https://conan.io/

--- a/.circleci/clang.conan_profile
+++ b/.circleci/clang.conan_profile
@@ -1,0 +1,13 @@
+[settings]
+arch=x86_64
+arch_build=x86_64
+compiler=clang
+compiler.version=9
+compiler.libcxx=libstdc++11
+os=Linux
+os_build=Linux
+build_type=Release
+
+[env]
+CC=/usr/bin/clang-9
+CXX=/usr/bin/clang++-9

--- a/.circleci/cmake_setup.sh
+++ b/.circleci/cmake_setup.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+## Perform the cmake setup with the proper flags turned on for the given
+## CI run.
+set -euo pipefail
+
+
+## ----------------------------------------------------------------------------
+## Constants & Utility Functions
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CLEAR='\033[0m'
+
+function fatal() { local msg=$1;
+    echo -e "${RED}[FATAL]${CLEAR} ${msg}" >&2
+    exit 1
+}
+function info() { local msg=$1;
+    echo -e "${GREEN}[INFO]${CLEAR} ${msg}"
+}
+
+
+## ----------------------------------------------------------------------------
+## Command Line Parsing
+
+SANITIZER_FLAGS=''
+COMPILATION_FLAGS=''
+
+function set_sanitizer_flags() { local sanitizer=$1;
+    case "$sanitizer" in
+        asan)
+            info "Running test with ASAN support"
+            SANITIZER_FLAGS="${SANITIZER_FLAGS} -DENABLE_ASAN=ON"
+            ;;
+        tsan)
+            info "Running test with TSAN support"
+            SANITIZER_FLAGS="${SANITIZER_FLAGS} -DENABLE_TSAN=ON"
+            ;;
+        msan)
+            info "Running test with MSAN support"
+            SANITIZER_FLAGS="${SANITIZER_FLAGS} -DENABLE_MSAN=ON"
+            ;;
+        ubsan)
+            info "Running test with UBSAN support"
+            SANITIZER_FLAGS="${SANITIZER_FLAGS} -DENABLE_UBSAN=ON"
+            ;;
+        none)
+            info "Running without sanitizers"
+            SANITIZER_FLAGS=''
+            ;;
+        *)
+            fatal "Unsupported sanitizer value provided '${sanitizer}'"
+            ;;
+    esac
+}
+
+function set_compilation_mode_flags() { local mode=$1;
+    case "$mode" in
+        Debug|debug)
+            info "Compiling in Debug mode"
+            COMPILATION_FLAGS='-DCMAKE_BUILD_TYPE=Debug'
+            ;;
+        Rel*|rel*)
+            info "Compiling in Release mode"
+            COMPILATION_FLAGS='-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+            ;;
+    esac
+}
+
+function print_help() {
+    cat <<EOF
+$(basename $0) [options]
+
+Setup CMake for CircleCI builds
+
+OPTIONS
+    -s | --with-sanitizer    Set sanitizer to one of [asan, tsan, msan, ubsan]
+    -c | --compilation-mode  Set compilation mode to one of [debug, release]
+    -h | --help              Show this help-message
+
+EOF
+}
+
+while (( "$#" )); do
+    case "$1" in
+        -s|--with-sanitizer)
+            [[ -z "$2" ]] && fatal "Must provide argument for '--with-sanitizer' flag"
+            set_sanitizer_flags "$2"
+            shift 2
+            ;;
+        -c|--compilation-mode)
+            [[ -z "$2" ]] && fatal "Must provide argument for '--compilation-mode' flag"
+            set_compilation_mode_flags "$2"
+            shift 2
+            ;;
+        -h|--help|help)
+            print_help
+            exit 1
+            ;;
+        *) # unsupported flags
+            print_help
+            fatal "Error: Unsupported flag $1"
+            ;;
+    esac
+done
+
+
+
+## ----------------------------------------------------------------------------
+## Setup CMake
+
+[[ -d build ]] || fatal "'build' directory seems to be missing"
+cd build
+
+env CC=/usr/bin/clang-9 CXX=/usr/bin/clang++-9 cmake ${COMPILATION_FLAGS} ${SANITIZER_FLAGS} ..

--- a/.circleci/conan_setup.sh
+++ b/.circleci/conan_setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -uexo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Install and configure conan
+pip install conan cmake
+mkdir -p "$HOME/.conan/profiles"
+cp "${DIR}/clang.conan_profile" "$HOME/.conan/profiles/default"
+conan config get
+      
+# Fetch 3rd party deps
+mkdir -p build
+cd build
+conan install ../pembroke         \
+    --build=missing               \
+    --env CC=/usr/bin/clang-9     \
+    --env CXX=/usr/bin/clang++-9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,9 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: ubuntu:19.10
-
+version: 2.1
+commands:
+  image_setup:
+    description: 'Setup the container image for all CI runs'
     steps:
       - checkout
-
       - run:
           name: Update APT Repos
           command: apt-get update
@@ -26,15 +23,31 @@ jobs:
       - run:
           name: Doc Tools Setup
           command: apt-get install -y doxygen && pip install -U sphinx breathe sphinx_rtd_theme
-      
+  build_pembroke:
+    description: 'Build pembroke'
+    parameters:
+      sanitizer:
+        type: string
+        default: none
+      build_mode:
+        type: string
+        default: debug
+    steps:
       - run:
           name: CMake Setup
-          command: cd build && cmake ..
-      
+          command: ./.circleci/cmake_setup.sh --with-sanitizer '<< parameters.sanitizer >>' --compilation-mode '<< parameters.build_mode >>'
       - run:
-          name: Compile
+          name: Build Library
           command: cd build && make
-      
       - run:
-          name: CTest
+          name: Test Library
           command: cd build && make test
+
+jobs:
+  build:
+    docker:
+      - image: ubuntu:19.10
+    steps:
+      - image_setup
+      - build_pembroke:
+          sanitizer: none

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
           command: ./.circleci/cmake_setup.sh --with-sanitizer '<< parameters.sanitizer >>' --compilation-mode '<< parameters.build_mode >>'
       - run:
           name: Build Library
-          command: cd build && make
+          command: cd build && make -j 2
       - run:
           name: Test Library
           command: cd build && make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,17 +9,17 @@ commands:
           command: apt-get update
 
       - run:
+          name: Build Tool Setup (clang)
+          command: apt-get install -y clang-9
+
+      - run:
           name: Build Tool Setup (python)
           command: apt-get install -y python3 python3-pip && pip3 install -U pip
 
       - run:
-          name: Build Tool Setup (conan)
-          command: pip install conan cmake && conan config get
+          name: Conan Setup & Install 3rd Party Dependencies
+          command: ./.circleci/conan_setup.sh
       
-      - run:
-          name: Conan Install 3rd Party Dependencies
-          command: mkdir build && cd build && conan install ../pembroke --build=missing
-
       - run:
           name: Doc Tools Setup
           command: apt-get install -y doxygen && pip install -U sphinx breathe sphinx_rtd_theme

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,11 @@
 version: 2.1
+
+# Define image to run all builds/tests under
+executors:
+  docker_ubuntu:
+    docker:
+      - image: ubuntu:19.10
+
 commands:
   image_setup:
     description: 'Setup the container image for all CI runs'
@@ -44,10 +51,58 @@ commands:
           command: cd build && make test
 
 jobs:
+  # Compile and test with all optimizations, do not run with any
+  # sanitizers
   build:
-    docker:
-      - image: ubuntu:19.10
+    executor: docker_ubuntu
     steps:
       - image_setup
       - build_pembroke:
-          sanitizer: none
+          build_mode: release
+
+  # ASAN build/test in debug mode
+  test_asan:
+    executor: docker_ubuntu
+    steps:
+      - image_setup
+      - build_pembroke:
+          sanitizer: asan
+
+  # TSAN build/test in debug mode
+  test_tsan:
+    executor: docker_ubuntu
+    steps:
+      - image_setup
+      - build_pembroke:
+          sanitizer: tsan
+
+  # MSAN build/test in debug mode
+  test_msan:
+    executor: docker_ubuntu
+    steps:
+      - image_setup
+      - build_pembroke:
+          sanitizer: msan
+
+  # UBSAN build/test in debug mode
+  test_ubsan:
+    executor: docker_ubuntu
+    steps:
+      - image_setup
+      - build_pembroke:
+          sanitizer: ubsan
+
+
+workflows:
+  version: 2
+  ci_workflow:
+    jobs:
+      - build
+      - test_asan:
+          requires: [build]
+      - test_tsan:
+          requires: [build]
+      - test_msan:
+          requires: [build]
+      - test_ubsan:
+          requires: [build]

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/pembroke/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/sbin/clang",
+            "cStandard": "c11",
+            "cppStandard": "c++20",
+            "intelliSenseMode": "clang-x64",
+            "configurationProvider": "vector-of-bool.cmake-tools"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Create Build Dir",
+            "type": "shell",
+            "command": "mkdir -p build",
+            "presentation": {
+                "echo": false,
+                "reveal": "silent",
+                "focus": false
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        {
+            "label": "Conan Install",
+            "type": "shell",
+            "command": "conan install --profile=clang ../pembroke",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "dependsOn": [
+                "Create Build Dir"
+            ],
+            "problemMatcher": []
+        }
+    ]
+}

--- a/cmake/asan.cmake
+++ b/cmake/asan.cmake
@@ -1,0 +1,17 @@
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    message(FATAL_ERROR "ASAN cannot be built in Release configuration")
+endif()
+
+macro(CHECK_ASAN COMPILER_ID ASAN_FLAGS)
+    if ("${COMPILER_ID}" STREQUAL "Clang")
+        set(${ASAN_FLAGS} "-fsanitize=address -fno-omit-frame-pointer")
+    else()
+        message(WARNING "Asan not supported for ${CMAKE_CXX_COMPILER_ID} compiler")
+    endif()
+endmacro()
+
+CHECK_ASAN(${CMAKE_C_COMPILER_ID} ASAN_C_FLAGS)
+CHECK_ASAN(${CMAKE_CXX_COMPILER_ID} ASAN_CXX_FLAGS)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ASAN_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ASAN_CXX_FLAGS}")

--- a/cmake/msan.cmake
+++ b/cmake/msan.cmake
@@ -1,0 +1,17 @@
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    message(FATAL_ERROR "MSAN cannot be built in Release configuration")
+endif()
+
+macro(CHECK_MSAN COMPILER_ID MSAN_FLAGS)
+    if ("${COMPILER_ID}" STREQUAL "Clang")
+        set(${MSAN_FLAGS} "-fsanitize=memory -fno-omit-frame-pointer")
+    else()
+        message(WARNING "Msan not supported for ${CMAKE_CXX_COMPILER_ID} compiler")
+    endif()
+endmacro()
+
+CHECK_MSAN(${CMAKE_C_COMPILER_ID} MSAN_C_FLAGS)
+CHECK_MSAN(${CMAKE_CXX_COMPILER_ID} MSAN_CXX_FLAGS)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MSAN_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MSAN_CXX_FLAGS}")

--- a/cmake/tsan.cmake
+++ b/cmake/tsan.cmake
@@ -1,0 +1,17 @@
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    message(FATAL_ERROR "TSAN cannot be built in Release configuration")
+endif()
+
+macro(CHECK_TSAN COMPILER_ID TSAN_FLAGS)
+    if ("${COMPILER_ID}" STREQUAL "Clang")
+        set(${TSAN_FLAGS} "-fsanitize=thread -fno-omit-frame-pointer")
+    else()
+        message(WARNING "Tsan not supported for ${CMAKE_CXX_COMPILER_ID} compiler")
+    endif()
+endmacro()
+
+CHECK_TSAN(${CMAKE_C_COMPILER_ID} TSAN_C_FLAGS)
+CHECK_TSAN(${CMAKE_CXX_COMPILER_ID} TSAN_CXX_FLAGS)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TSAN_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${TSAN_CXX_FLAGS}")

--- a/cmake/ubsan.cmake
+++ b/cmake/ubsan.cmake
@@ -1,0 +1,17 @@
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    message(FATAL_ERROR "UBSAN cannot be built in Release configuration")
+endif()
+
+macro(CHECK_UBSAN COMPILER_ID UBSAN_FLAGS)
+    if ("${COMPILER_ID}" STREQUAL "Clang")
+        set(${UBSAN_FLAGS} "-fsanitize=undefined -fno-omit-frame-pointer")
+    else()
+        message(WARNING "UBsan not supported for ${CMAKE_CXX_COMPILER_ID} compiler")
+    endif()
+endmacro()
+
+CHECK_UBSAN(${CMAKE_C_COMPILER_ID} UBSAN_C_FLAGS)
+CHECK_UBSAN(${CMAKE_CXX_COMPILER_ID} UBSAN_CXX_FLAGS)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${UBSAN_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${UBSAN_CXX_FLAGS}")

--- a/pembroke/CMakeLists.txt
+++ b/pembroke/CMakeLists.txt
@@ -1,12 +1,34 @@
-## ---
+## ----------------------------------------------------------------------------
 ## Setup/Include Dependencies (Conan)
-## ---
+##
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-## ---
+
+## ----------------------------------------------------------------------------
+## Sanatizer Setup
+## 
+option(ENABLE_ASAN  "Enable address sanitizer"            OFF)
+option(ENABLE_MSAN  "Enable memory sanitizer"             OFF)
+option(ENABLE_TSAN  "Enable thread sanitizer"             OFF)
+option(ENABLE_UBSAN "Enable undefined behavior sanitizer" OFF)
+
+if (ENABLE_ASAN)
+    include(asan)
+endif()
+if (ENABLE_MSAN)
+    include(msan)
+endif()
+if (ENABLE_TSAN)
+    include(tsan)
+endif()
+if (ENABLE_UBSAN)
+    include(ubsan)
+endif()
+
+## ----------------------------------------------------------------------------
 ## Pembroke Library Definition
-## ---
+## 
 add_library(pembroke
     src/pembroke/buffer.cpp
     src/pembroke/event/delayed.cpp
@@ -28,9 +50,9 @@ target_include_directories(pembroke
 )
 
 
-## ---
+## ----------------------------------------------------------------------------
 ## Testing
-## ---
+##
 find_package(Catch2 REQUIRED)
 add_executable(tests
     src/pembroke/main_test.cpp


### PR DESCRIPTION
Add the following sanitizers to the CircleCI test runs:
* ASAN
* TSAN
* MSAN
* UBSAN

A bit of refactoring was necessary to the CircleCI configurations and some refactoring out into various setup scripts was necessary to keep complexity to a minimum in the file. Additionally, the CI builds are configured to run a basic optimzied build + test first, and then (in parallel) compile and run tests under all of the sanitizers.

__Follow-up work__ should be done to introduce `clang-tidy` into the mix.